### PR TITLE
Fix property inspector.

### DIFF
--- a/addons/mood/plugin.cfg
+++ b/addons/mood/plugin.cfg
@@ -3,5 +3,5 @@
 name="Mood"
 description="A flexible, component-state-based Finite State Machine system."
 author="Zoeticist Games"
-version="0.6.0"
+version="0.8.0"
 script="plugin.gd"

--- a/addons/mood/scenes/editors/mood_ui_condition_input.gd
+++ b/addons/mood/scenes/editors/mood_ui_condition_input.gd
@@ -30,7 +30,6 @@ const ActionSelectorScene: PackedScene = preload("res://addons/mood/scenes/edito
 #region action Hooks
 
 func _on_popup_button_pressed() -> void:
-	print("pressed")
 	if _action_selector:
 		_action_selector.queue_free()
 
@@ -41,7 +40,6 @@ func _on_popup_button_pressed() -> void:
 	_action_selector.popup_exclusive(EditorInterface.get_editor_main_screen())
 
 func _update_action_list(actions: Array[StringName]) -> void:
-	print("updating")
 	condition.actions = actions
 	condition.notify_property_list_changed()
 	_action_selector.queue_free()

--- a/addons/mood/scenes/editors/popups/mood_ui_method_selector.gd
+++ b/addons/mood/scenes/editors/popups/mood_ui_method_selector.gd
@@ -11,7 +11,10 @@ extends ConfirmationDialog
 
 		target_node = val
 		_refresh_items()
-
+@export var selected_item: StringName:
+	set(val):
+		selected_item = val
+		_refresh_items()
 
 const VALID_TYPES = [
 	TYPE_STRING, TYPE_STRING_NAME, TYPE_INT, TYPE_FLOAT, TYPE_BOOL
@@ -51,24 +54,6 @@ func _on_custom_action(action: StringName) -> void:
 
 #endregion
 
-#region Public Methods
-
-func select_item_by_text(text: String) -> void:
-	if !is_instance_valid(target_node):
-		return
-
-	var idx := 0
-	for sig in target_node.get_method_list():
-		if len(sig["args"]) - len(sig["default_args"]) != 0:
-			continue
-
-		if sig["name"] == text:
-			item_list.select(idx)
-			break
-
-		idx += 1
-
-#endregion
 
 #region Private Methods
 
@@ -84,6 +69,7 @@ func _refresh_items() -> void:
 	methods.sort_custom(func(l, r): return l["name"] < r["name"])
 	
 	var filter = %MethodSearch.text
+	var added_selected := false
 
 	for meth in methods:
 		if len(meth["args"]) - len(meth["default_args"]) > 0:
@@ -95,7 +81,16 @@ func _refresh_items() -> void:
 		if len(filter) > 0 and not meth["name"].begins_with(filter):
 			continue
 
-		item_list.add_item(meth["name"])
+		var idx := item_list.add_item(meth["name"])
+		if meth["name"] == selected_item:
+			item_list.select(idx)
+			added_selected = true
+
+	# ensure presence of previously selected item even if filter would reject it.
+	if selected_item != null and not added_selected:
+		var idx := item_list.add_item(selected_item)
+		item_list.select(idx)
+		item_list.sort_items_by_text()
 
 #endregion
 


### PR DESCRIPTION
# Chores

* removed some debug prints (whoops!)
* updated version to 0.8.0

# Fixes

* previously selected methods will stay selected on subsequent pop-ups and not give an error.

# Features

* enum property handling was so poor as to be non-existent, so the fact that it works now is something I'm considering a new feature.
* when filtering methods, the selected method will always appear even if it wouldn't match the filter.
* when changing property types in the property editor, the condition's criteria will reset, which should prevent a number of type-mismatch errors.
* when changing property types in the property editor, if the resultant type is a text-entry type, that input will grab focus.
