### PR TITLE
feat: Refactor signals and inputs handling

### DIFF
--- a/addons/mood/nodes/conditions/mood_condition_input.gd
+++ b/addons/mood/nodes/conditions/mood_condition_input.gd
@@ -97,31 +97,60 @@ const SubEditor := preload("res://addons/mood/scenes/editors/mood_ui_condition_i
 ## are pressed, as per all the below rules.
 @export var invert_validity := false
 
-@export_group("Condition Rules", "rule")
-## If true, this condition is valid only when ALL actions are pressed/echoed, instead
-## of ANY actions in the list.
-@export var rule_all_actions: bool = true
-## This condition becomes valid whenever the initial press occurs. It may become
-## invalid in several ways:
-## * InvalidTrigger.MOOD_CHANGE -- the rule is valid only until the mood changes.
-## * InvalidTrigger.TIMEOUT -- the rule is valid until a timeout occurs.
-## * InvalidTrigger.RELEASE -- the rule becomes invalid as soon as the action
-##   (or actions if rule_all_actions is true) is released.
-## * InvalidTrigger.TIMEOUT_OR_RELEASE -- TIMEOUT + RELEASE.
-@export var rule_become_invalid_when := InvalidTrigger.RELEASE
-## If [param rule_become_invalid_when] is InvalidTrigger.TIMEOUT, how many seconds
-## until the rule becomes invalid again
-@export_range(0.0, 20.0, 0.25, "or_greater") var rule_timeout_sec := 0.25
-## If true and [param rule_become_invalid_when] is InvalidTrigger.TIMEOUT, echoes
-## of the action(s) will refresh the timeout.
-@export var rule_timeout_refresh_on_echo := false
-## If true and [param rule_becomes_invalid_when] is InvalidTrigger.RELEASE or TIMEOUT_OR_RELEASE,
-## the validity will only be cleared once all actions are released, instead of
-## when any action is released.
-@export var rule_only_invalid_when_all_released := false
-## If true, the timeout timer will be cleared when any/all actions are released,
-## as per rule_only_invalid_when_all_released
-@export var rule_reset_timer_on_release := true
+@export_group("Trigger Conditions", "trigger_")
+
+## By default, inputs are processed and handled generically and globally,
+## meaning that if you press [code]ui_accept[/code] then [b]all[/b]
+## [code]MoodConditionInput[/code] nodes watching that action will flag it as
+## being pressed. If this is set to [code]true[/code], though, it will only
+## process the input if the parent [member MoodChild.mood] is the
+## [member MoodMachine.current_mood].
+@export var trigger_consider_only_if_current := false:
+	set(val):
+		trigger_consider_only_if_current = val
+		property_list_changed.emit() # allow_echo_to_trigger hide/show
+
+## Generally, an action will be flagged as pressed when the initial press occurs.
+## However, if [member trigger_consider_only_if_current] is set, then a pressed button
+## may [i]not[/i] trigger that tracking. This flag allows echo presses to trigger
+## the pressed flag in that case.
+@export var trigger_echo_counts_as_press := false
+
+## If true, this condition is valid only when ALL actions are pressed/echoed,
+## instead of ANY actions in the list.
+@export var trigger_require_all_actions := false
+
+@export_group("Rule Clearance", "clear_")
+
+## If true, reset validity when entering the mood this condition belongs to.
+@export var clear_on_mood_enter := false
+## If true, reset validity when exiting the mood this condition belongs to.
+@export var clear_on_mood_exit := false
+## If true, reset validity when one or all actions are released. see
+## [member clear_on_release_only_when_all_are_released] for more information.
+@export var clear_on_action_release := true:
+	set(val):
+		clear_on_action_release = val
+		property_list_changed.emit()
+## If true, reset validity when timeout configuration applies.
+@export var clear_on_timeout := false:
+	set(val):
+		clear_on_timeout = val
+		property_list_changed.emit()
+## If true, require no actions to be pressed to trigger action-release clearing.
+## Otherwise, the release of any action will clear validity, [i]even if other
+## actions are still pressed[/i].
+@export var clear_on_release_only_when_all_are_released := true
+
+@export_group("Timeout Clearance", "timeout_")
+## If [member clear_on_timeout] is [code]true[/code], how many seconds
+## until the rule clears.
+@export_range(0.0, 20.0, 0.25, "or_greater") var timeout_timeout_seconds := 0.25
+## If true, an action being echoed will reset the timeout timer.
+@export var timeout_reset_on_action_echo := false
+## If true, the timeout timer will be zeroed when an action is released, as per
+## the [member clear_on_release_only_when_all_are_released] flag logic.
+@export var timeout_clear_on_action_release := true
 
 #endregion
 
@@ -141,8 +170,7 @@ var _timer: SceneTreeTimer
 
 ## Connect to the [InputTracker] action signals when ready.
 func _ready() -> void:
-	if invert_validity:
-		_valid = true
+	_valid = invert_validity
 
 	if has_node(^"/root/InputTracker"): # singleton
 		var it_autoload := get_node(^"/root/InputTracker")
@@ -161,7 +189,19 @@ func _get_configuration_warnings() -> PackedStringArray:
 
 ## Used by the Plugin to skip fields.
 func should_skip_property(field: String) -> bool:
-	return field == "actions"
+	if field == "actions":
+		return true
+	
+	if field.begins_with("timeout_") and not clear_on_timeout:
+		return true
+
+	if field == "clear_on_release_only_when_all_are_released":
+		return not (clear_on_action_release or (clear_on_timeout and timeout_clear_on_action_release))
+
+	if field == "trigger_echo_counts_as_press" and not trigger_consider_only_if_current:
+		return true
+	
+	return false
 
 #endregion
 
@@ -182,8 +222,15 @@ func is_valid(cache: Dictionary = {}) -> bool:
 
 ## When we exit the mood this condition belongs to, we always set ourselves to
 ## invalid.
+func _enter_mood(_next_mood: Mood) -> void:
+	if clear_on_mood_enter:
+		_valid = invert_validity
+
+## When we exit the mood this condition belongs to, we always set ourselves to
+## invalid.
 func _exit_mood(_next_mood: Mood) -> void:
-	_valid = false
+	if clear_on_mood_exit:
+		_valid = invert_validity
 
 #endregion
 
@@ -196,40 +243,57 @@ func _on_action_pressed(action: String, event: InputEvent) -> void:
 	if action not in actions:
 		return
 
+	if trigger_consider_only_if_current and not mood.is_current_mood():
+		return
+
 	if action not in _pressed_actions:
 		_pressed_actions.append(action)
 
-	if !rule_all_actions or _pressed_actions.size() == actions.size():
+	if !trigger_require_all_actions or _pressed_actions.size() == actions.size():
 		_valid = !invert_validity
-		if rule_become_invalid_when in [InvalidTrigger.TIMEOUT, InvalidTrigger.TIMEOUT_OR_RELEASE]:
-			if _timer == null or rule_timeout_refresh_on_echo:
+
+		if clear_on_timeout:
+			if _timer == null or timeout_reset_on_action_echo:
 				if _timer != null: # refreshing by killing
 					_timer.timeout.disconnect(_on_timeout)
-				_timer = get_tree().create_timer(rule_timeout_sec, false)
+				_timer = get_tree().create_timer(timeout_timeout_seconds, false)
 				_timer.timeout.connect(_on_timeout)
 
 func _on_action_echoed(action: String, event: InputEvent) -> void:
 	if action not in actions:
 		return
 
-	if _timer != null and rule_timeout_refresh_on_echo:
+	if trigger_consider_only_if_current:
+		if not mood.is_current_mood():
+			return
+
+		if action not in _pressed_actions and trigger_echo_counts_as_press:
+			_on_action_pressed(action, event) # treat this like initial press first.
+
+	if action in _pressed_actions and _timer != null and timeout_reset_on_action_echo:
 		_timer.timeout.disconnect(_on_timeout)
-		_timer = get_tree().create_timer(rule_timeout_sec, false)
+		_timer = get_tree().create_timer(timeout_timeout_seconds, false)
 
 func _on_action_released(action: String, event: InputEvent) -> void:
 	if action not in actions:
 		return
 
+	if action not in _pressed_actions:
+		return
+
+	if trigger_consider_only_if_current and not mood.is_current_mood():
+		return
+
 	_pressed_actions.erase(action)
 
-	if _timer != null and rule_reset_timer_on_release: # refreshing by killing
-		_timer.timeout.disconnect(_on_timeout)
-		_timer = null
-
-	if rule_become_invalid_when in [InvalidTrigger.RELEASE, InvalidTrigger.TIMEOUT_OR_RELEASE]:
-		if !rule_only_invalid_when_all_released or _pressed_actions.is_empty():
+	if clear_on_action_release:
+		if (not clear_on_release_only_when_all_are_released) or _pressed_actions.is_empty():
 			_valid = invert_validity
+
+	if _timer != null and timeout_clear_on_action_release: # refreshing by killing
+		if (not clear_on_release_only_when_all_are_released) or _pressed_actions.is_empty():
+			_timer.timeout.disconnect(_on_timeout)
+			_timer = null
 
 func _on_timeout() -> void:
 	_valid = invert_validity
-	_timer = null

--- a/addons/mood/nodes/conditions/mood_condition_signal.gd
+++ b/addons/mood/nodes/conditions/mood_condition_signal.gd
@@ -56,38 +56,66 @@ var _signal_target: Node
 		signal_triggers = value
 		_refresh_signals()
 
+## By default, when a signal is received, we treat this condition as valid.
+## Setting this flag to [code]true[/code] inverts the relationship, so this
+## condition is valid [i]until[/i] the signal is received.
+@export var invert_validity := false
+
 @export_group("Signal Flag Trigger Conditions", "trigger_")
+
+## By default, inputs are processed and handled generically and globally,
+## meaning that if you press [code]ui_accept[/code] then [b]all[/b]
+## [code]MoodConditionInput[/code] nodes watching that action will flag it as
+## being pressed. If this is set to [code]true[/code], though, it will only
+## process the input if the parent [member MoodChild.mood] is the
+## [member MoodMachine.current_mood].
+@export var trigger_consider_only_if_current := false
+
 ## how many times one of the signals must be triggered before the flag is tripped.
 @export var trigger_after_n_times := 1
+
 ## if set, when the flag would be set, delay the actual set until the
 ## timer ends.
 @export var trigger_delay_timer: Timer
 
 @export_group("Signal Flag Clearance", "clear_")
-## If true, the received signal flag (when true) will be set to false
-## once the transition occurs.
-@export var clear_on_transition := true
-## If set, the received signal flag (when true) will be set to false
-## if the signal is received this many times, even if the machine
-## has not yet transitioned to the condition's mood.
+
+## If true, the received signal flag and count will be reset when this mood is
+## exited.
+@export var clear_on_mood_exit := true
+
+## If true, the received signal flag and count will be reset when this mood is
+## entered.
+@export var clear_on_mood_enter := true
+
+## If set to greater than [code]0[/code], the received signal flag and count
+## will be reset after the signal is received this many times. This allows you
+## to, for instance, provide "windows" based on trigger times, e.g. if [member trigger_after_n_times]
+## is 5 and this is 10, then this condition is valid from the 5th time until the
+## 10th time.
 @export var clear_after_count := 0
-## If set, start the timer when signal is received and clear
-## when the timer is done.
+
+## If set, start the timer when signal is received and clear when the timer is
+## done.
 @export var clear_after_signal_received_timer: Timer
-## If set, start the timer when signal is received and clear
-## when the timer is done.
+
+## If set, start the timer when signal is received and clear when the timer is
+## done.
 @export var clear_after_signal_flag_set_timer: Timer
 
 #endregion
 
 #region Private Variables
 
-var _received_signal := false
+var _valid := false
 var _received_count := 0
 
 #endregion
 
 #region Overrides
+
+func _ready() -> void:
+	clear()
 
 func _get_configuration_warnings() -> PackedStringArray:
 	var res := []
@@ -107,22 +135,29 @@ func _property_get_revert(property: StringName) -> Variant:
 		_:
 			return null
 
+func _enter_mood(_previous_mood: Mood) -> void:
+	if clear_on_mood_enter:
+		clear()
+
 func _exit_mood(_next_mood: Mood) -> void:
-	if clear_on_transition:
-		_received_signal = false
+	if clear_on_mood_exit:
+		clear()
 
 #endregion
 
 #region Public Methods
 
+func clear() -> void:
+	_valid = invert_validity
+	_received_count = 0
+
 ## Used by the Plugin to skip fields which are represented in the [method get_editor] return.
 func should_skip_property(field: String) -> bool:
 	return field in ["signal_triggers"]
 
-
 ## Whether or not the condition is valid. Used for transitioning state.
 func is_valid(cache: Dictionary = {}) -> bool:
-	return _received_signal
+	return _valid
 
 #endregion
 
@@ -146,21 +181,26 @@ func _refresh_signals() -> void:
 #region Signal Hooks
 
 func _receive_signal() -> void:
+	if trigger_consider_only_if_current and not mood.is_current_mood():
+		return
+
 	_received_count += 1
 
 	if clear_after_count > 0 and _received_count >= clear_after_count:
-		_received_signal = false
+		clear()
 
 	if _received_count >= trigger_after_n_times:
 		if trigger_delay_timer:
 			await _schedule_timer(trigger_delay_timer)
 
-		_received_signal = true
+		# validity is set here!
+		print(name, ": setting _valid to true")
+		_valid = !invert_validity
 
 		if clear_after_signal_flag_set_timer:
 			await _schedule_timer(clear_after_signal_flag_set_timer)
-			_received_signal = false
+			clear()
 
 	if clear_after_signal_received_timer:
 		await _schedule_timer(clear_after_signal_received_timer)
-		_received_signal = false
+		clear()

--- a/addons/mood/nodes/mood_child.gd
+++ b/addons/mood/nodes/mood_child.gd
@@ -34,6 +34,15 @@ var mood: Mood:
 		
 		_mood = value
 
+		if has_method("_enter_mood"):
+			var em := Callable(self, "_enter_mood")
+			if not _mood.mood_entered.is_connected(em):
+				_mood.mood_entered.connect(em)
+		if has_method("_exit_mood"):
+			var em := Callable(self, "_exit_mood")
+			if not _mood.mood_exited.is_connected(em):
+				_mood.mood_exited.connect(em)
+
 		# assign our processing status to match the mood's.
 		set_process(_mood.is_processing())
 		set_physics_process(_mood.is_physics_processing())

--- a/addons/mood/plugin.cfg
+++ b/addons/mood/plugin.cfg
@@ -3,5 +3,5 @@
 name="Mood"
 description="A flexible, component-state-based Finite State Machine system."
 author="Zoeticist Games"
-version="0.8.1"
+version="0.8.2"
 script="plugin.gd"

--- a/examples/scenes/input_state_test.tscn
+++ b/examples/scenes/input_state_test.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=15 format=3 uid="uid://bflpa67sbry4n"]
+[gd_scene load_steps=14 format=3 uid="uid://bflpa67sbry4n"]
 
 [ext_resource type="Script" uid="uid://cexmmjes4fv" path="res://examples/scenes/player.gd" id="1_an8x8"]
 [ext_resource type="Texture2D" uid="uid://b3vsw8i10o171" path="res://icon.svg" id="1_bom16"]
@@ -6,7 +6,6 @@
 [ext_resource type="Script" uid="uid://0re6tuqk5egu" path="res://addons/mood/nodes/mood.gd" id="3_u1pv1"]
 [ext_resource type="Script" uid="uid://corvum2mgs3oh" path="res://addons/mood/nodes/mood_transition.gd" id="4_y8xmq"]
 [ext_resource type="Script" uid="uid://b66vkfnusc0f6" path="res://addons/mood/nodes/conditions/mood_condition_input.gd" id="5_fiv1m"]
-[ext_resource type="Script" uid="uid://lth7jksuyveq" path="res://addons/mood/nodes/conditions/mood_condition_timeout.gd" id="7_0ebda"]
 [ext_resource type="Script" uid="uid://b448uxn08i6o1" path="res://addons/mood/nodes/conditions/mood_condition_property.gd" id="7_u1pv1"]
 [ext_resource type="Script" uid="uid://6fcf7wp86vg3" path="res://examples/scenes/move_target.gd" id="8_fiv1m"]
 [ext_resource type="Script" uid="uid://qrxr1kr7m25j" path="res://examples/scenes/drain_stamina.gd" id="8_y8xmq"]
@@ -53,15 +52,7 @@ metadata/_custom_type_script = "uid://corvum2mgs3oh"
 [node name="PressingMoveKeys" type="Node" parent="Player/MoveMachine/Idle/TransitionToMoving"]
 script = ExtResource("5_fiv1m")
 actions = Array[StringName]([&"ui_down", &"ui_left", &"ui_right", &"ui_up"])
-trigger_echo_counts_as_press = null
 metadata/_custom_type_script = "uid://b66vkfnusc0f6"
-
-[node name="MoodConditionTimeout" type="Node" parent="Player/MoveMachine/Idle/TransitionToMoving"]
-script = ExtResource("7_0ebda")
-time_sec = 2.0
-validation_mode = 3
-trigger_sets_valid_to = false
-metadata/_custom_type_script = "uid://lth7jksuyveq"
 
 [node name="BeginRaging" type="Node" parent="Player/MoveMachine/Idle" node_paths=PackedStringArray("to_mood")]
 script = ExtResource("4_y8xmq")
@@ -93,11 +84,7 @@ metadata/_custom_type_script = "uid://corvum2mgs3oh"
 script = ExtResource("5_fiv1m")
 actions = Array[StringName]([&"ui_left", &"ui_right", &"ui_up", &"ui_down"])
 invert_validity = true
-trigger_echo_counts_as_press = null
 clear_on_mood_exit = true
-timeout_timeout_seconds = null
-timeout_reset_on_action_echo = null
-timeout_clear_on_action_release = null
 metadata/_custom_type_script = "uid://b66vkfnusc0f6"
 
 [node name="TransitionToSprinting" type="Node" parent="Player/MoveMachine/Moving" node_paths=PackedStringArray("to_mood")]
@@ -132,10 +119,20 @@ trigger_consider_only_if_current = true
 script = ExtResource("3_u1pv1")
 metadata/_custom_type_script = "uid://0re6tuqk5egu"
 
+[node name="TransitionToIdle" type="Node" parent="Player/MoveMachine/Sprinting" node_paths=PackedStringArray("to_mood")]
+script = ExtResource("4_y8xmq")
+to_mood = NodePath("../../Idle")
+metadata/_custom_type_script = "uid://corvum2mgs3oh"
+
+[node name="NotPressingMoveKeys" type="Node" parent="Player/MoveMachine/Sprinting/TransitionToIdle"]
+script = ExtResource("5_fiv1m")
+actions = Array[StringName]([&"ui_left", &"ui_right", &"ui_up", &"ui_down"])
+invert_validity = true
+metadata/_custom_type_script = "uid://b66vkfnusc0f6"
+
 [node name="TransitionToMoving" type="Node" parent="Player/MoveMachine/Sprinting" node_paths=PackedStringArray("to_mood")]
 script = ExtResource("4_y8xmq")
 to_mood = NodePath("../../Moving")
-and_all_conditions = false
 metadata/_custom_type_script = "uid://corvum2mgs3oh"
 
 [node name="NotSprinting" type="Node" parent="Player/MoveMachine/Sprinting/TransitionToMoving" node_paths=PackedStringArray("property_target")]
@@ -146,22 +143,6 @@ comparator = 5
 criteria = "Sprinting"
 is_callable = true
 metadata/_custom_type_script = "uid://b448uxn08i6o1"
-
-[node name="TransitionToIdle" type="Node" parent="Player/MoveMachine/Sprinting" node_paths=PackedStringArray("to_mood")]
-script = ExtResource("4_y8xmq")
-to_mood = NodePath("../../Idle")
-metadata/_custom_type_script = "uid://corvum2mgs3oh"
-
-[node name="NotPressingMoveKeys" type="Node" parent="Player/MoveMachine/Sprinting/TransitionToIdle"]
-script = ExtResource("5_fiv1m")
-actions = Array[StringName]([&"ui_left", &"ui_right", &"ui_up", &"ui_down"])
-invert_validity = true
-trigger_echo_counts_as_press = null
-trigger_require_all_actions = true
-timeout_timeout_seconds = null
-timeout_reset_on_action_echo = null
-timeout_clear_on_action_release = null
-metadata/_custom_type_script = "uid://b66vkfnusc0f6"
 
 [node name="SprintUpdatePosition" type="Node" parent="Player/MoveMachine/Sprinting"]
 script = ExtResource("8_fiv1m")
@@ -197,11 +178,6 @@ trigger_echo_counts_as_press = true
 trigger_require_all_actions = true
 clear_on_mood_enter = true
 clear_on_mood_exit = true
-clear_on_action_release = null
-clear_on_release_only_when_all_are_released = null
-timeout_timeout_seconds = null
-timeout_reset_on_action_echo = null
-timeout_clear_on_action_release = null
 
 [node name="SprintUpdatePosition" type="Node" parent="Player/MoveMachine/Raging"]
 script = ExtResource("8_fiv1m")
@@ -237,17 +213,6 @@ criteria = 1
 [node name="PressingSprint" type="Node" parent="Player/SprintMachine/NotSprinting/ToSprinting"]
 script = ExtResource("5_fiv1m")
 actions = Array[StringName]([&"sprinting"])
-trigger_consider_only_if_current = null
-trigger_echo_counts_as_press = null
-trigger_require_all_actions = null
-clear_on_mood_enter = null
-clear_on_mood_exit = null
-clear_on_action_release = null
-clear_on_timeout = null
-clear_on_release_only_when_all_are_released = null
-timeout_timeout_seconds = null
-timeout_reset_on_action_echo = null
-timeout_clear_on_action_release = null
 metadata/_custom_type_script = "uid://b66vkfnusc0f6"
 
 [node name="Sprinting" type="Node" parent="Player/SprintMachine"]
@@ -270,17 +235,7 @@ criteria = 0
 [node name="NotPressingSprint" type="Node" parent="Player/SprintMachine/Sprinting/ToNotSprinting"]
 script = ExtResource("5_fiv1m")
 actions = Array[StringName]([&"sprinting"])
-trigger_consider_only_if_current = null
-trigger_echo_counts_as_press = null
-trigger_require_all_actions = null
-clear_on_mood_enter = null
-clear_on_mood_exit = null
-clear_on_action_release = null
-clear_on_timeout = null
-clear_on_release_only_when_all_are_released = null
-timeout_timeout_seconds = null
-timeout_reset_on_action_echo = null
-timeout_clear_on_action_release = null
+invert_validity = true
 metadata/_custom_type_script = "uid://b66vkfnusc0f6"
 
 [node name="UI" type="Control" parent="." node_paths=PackedStringArray("stamina_label", "move_machine_label", "sprint_machine_label")]
@@ -300,6 +255,7 @@ offset_bottom = 40.0
 
 [node name="Stamina" type="Label" parent="UI/VBoxContainer"]
 layout_mode = 2
+text = "100"
 
 [node name="MoveMachineState" type="Label" parent="UI/VBoxContainer"]
 layout_mode = 2

--- a/examples/scenes/input_state_test.tscn
+++ b/examples/scenes/input_state_test.tscn
@@ -52,9 +52,8 @@ metadata/_custom_type_script = "uid://corvum2mgs3oh"
 
 [node name="PressingMoveKeys" type="Node" parent="Player/MoveMachine/Idle/TransitionToMoving"]
 script = ExtResource("5_fiv1m")
-actions = Array[StringName]([&"ui_cancel", &"ui_left", &"ui_right", &"ui_up"])
-rule_all_actions = false
-rule_only_invalid_when_all_released = true
+actions = Array[StringName]([&"ui_down", &"ui_left", &"ui_right", &"ui_up"])
+trigger_echo_counts_as_press = null
 metadata/_custom_type_script = "uid://b66vkfnusc0f6"
 
 [node name="MoodConditionTimeout" type="Node" parent="Player/MoveMachine/Idle/TransitionToMoving"]
@@ -73,6 +72,7 @@ metadata/_custom_type_script = "uid://corvum2mgs3oh"
 script = ExtResource("11_vrm4l")
 signal_target = NodePath("../../../..")
 signal_triggers = Array[String](["start_rage"])
+trigger_consider_only_if_current = true
 
 [node name="RecoverStamina" type="Node" parent="Player/MoveMachine/Idle"]
 script = ExtResource("8_y8xmq")
@@ -93,8 +93,11 @@ metadata/_custom_type_script = "uid://corvum2mgs3oh"
 script = ExtResource("5_fiv1m")
 actions = Array[StringName]([&"ui_left", &"ui_right", &"ui_up", &"ui_down"])
 invert_validity = true
-rule_all_actions = false
-rule_only_invalid_when_all_released = true
+trigger_echo_counts_as_press = null
+clear_on_mood_exit = true
+timeout_timeout_seconds = null
+timeout_reset_on_action_echo = null
+timeout_clear_on_action_release = null
 metadata/_custom_type_script = "uid://b66vkfnusc0f6"
 
 [node name="TransitionToSprinting" type="Node" parent="Player/MoveMachine/Moving" node_paths=PackedStringArray("to_mood")]
@@ -113,6 +116,17 @@ metadata/_custom_type_script = "uid://b448uxn08i6o1"
 [node name="MoveUpdatePosition" type="Node" parent="Player/MoveMachine/Moving"]
 script = ExtResource("8_fiv1m")
 metadata/_custom_type_script = "uid://d17xu8yphmvpi"
+
+[node name="BeginRaging2" type="Node" parent="Player/MoveMachine/Moving" node_paths=PackedStringArray("to_mood")]
+script = ExtResource("4_y8xmq")
+to_mood = NodePath("../../Raging")
+metadata/_custom_type_script = "uid://corvum2mgs3oh"
+
+[node name="RageTriggered" type="Node" parent="Player/MoveMachine/Moving/BeginRaging2" node_paths=PackedStringArray("signal_target")]
+script = ExtResource("11_vrm4l")
+signal_target = NodePath("../../../..")
+signal_triggers = Array[String](["start_rage"])
+trigger_consider_only_if_current = true
 
 [node name="Sprinting" type="Node" parent="Player/MoveMachine"]
 script = ExtResource("3_u1pv1")
@@ -142,8 +156,11 @@ metadata/_custom_type_script = "uid://corvum2mgs3oh"
 script = ExtResource("5_fiv1m")
 actions = Array[StringName]([&"ui_left", &"ui_right", &"ui_up", &"ui_down"])
 invert_validity = true
-rule_all_actions = false
-rule_only_invalid_when_all_released = true
+trigger_echo_counts_as_press = null
+trigger_require_all_actions = true
+timeout_timeout_seconds = null
+timeout_reset_on_action_echo = null
+timeout_clear_on_action_release = null
 metadata/_custom_type_script = "uid://b66vkfnusc0f6"
 
 [node name="SprintUpdatePosition" type="Node" parent="Player/MoveMachine/Sprinting"]
@@ -163,13 +180,28 @@ metadata/_custom_type_script = "uid://0re6tuqk5egu"
 [node name="BackToIdle" type="Node" parent="Player/MoveMachine/Raging" node_paths=PackedStringArray("to_mood")]
 script = ExtResource("4_y8xmq")
 to_mood = NodePath("../../Idle")
+and_all_conditions = false
 metadata/_custom_type_script = "uid://corvum2mgs3oh"
 
-[node name="MoodConditionSignal" type="Node" parent="Player/MoveMachine/Raging/BackToIdle" node_paths=PackedStringArray("signal_target")]
+[node name="EndRageSignal" type="Node" parent="Player/MoveMachine/Raging/BackToIdle" node_paths=PackedStringArray("signal_target")]
 script = ExtResource("11_vrm4l")
 signal_target = NodePath("../../../..")
 signal_triggers = Array[String](["end_rage"])
 metadata/_custom_type_script = "uid://bapwnus850ael"
+
+[node name="Press To End" type="Node" parent="Player/MoveMachine/Raging/BackToIdle"]
+script = ExtResource("5_fiv1m")
+actions = Array[StringName]([&"ui_text_indent"])
+trigger_consider_only_if_current = true
+trigger_echo_counts_as_press = true
+trigger_require_all_actions = true
+clear_on_mood_enter = true
+clear_on_mood_exit = true
+clear_on_action_release = null
+clear_on_release_only_when_all_are_released = null
+timeout_timeout_seconds = null
+timeout_reset_on_action_echo = null
+timeout_clear_on_action_release = null
 
 [node name="SprintUpdatePosition" type="Node" parent="Player/MoveMachine/Raging"]
 script = ExtResource("8_fiv1m")
@@ -205,6 +237,17 @@ criteria = 1
 [node name="PressingSprint" type="Node" parent="Player/SprintMachine/NotSprinting/ToSprinting"]
 script = ExtResource("5_fiv1m")
 actions = Array[StringName]([&"sprinting"])
+trigger_consider_only_if_current = null
+trigger_echo_counts_as_press = null
+trigger_require_all_actions = null
+clear_on_mood_enter = null
+clear_on_mood_exit = null
+clear_on_action_release = null
+clear_on_timeout = null
+clear_on_release_only_when_all_are_released = null
+timeout_timeout_seconds = null
+timeout_reset_on_action_echo = null
+timeout_clear_on_action_release = null
 metadata/_custom_type_script = "uid://b66vkfnusc0f6"
 
 [node name="Sprinting" type="Node" parent="Player/SprintMachine"]
@@ -227,7 +270,17 @@ criteria = 0
 [node name="NotPressingSprint" type="Node" parent="Player/SprintMachine/Sprinting/ToNotSprinting"]
 script = ExtResource("5_fiv1m")
 actions = Array[StringName]([&"sprinting"])
-invert_validity = true
+trigger_consider_only_if_current = null
+trigger_echo_counts_as_press = null
+trigger_require_all_actions = null
+clear_on_mood_enter = null
+clear_on_mood_exit = null
+clear_on_action_release = null
+clear_on_timeout = null
+clear_on_release_only_when_all_are_released = null
+timeout_timeout_seconds = null
+timeout_reset_on_action_echo = null
+timeout_clear_on_action_release = null
 metadata/_custom_type_script = "uid://b66vkfnusc0f6"
 
 [node name="UI" type="Control" parent="." node_paths=PackedStringArray("stamina_label", "move_machine_label", "sprint_machine_label")]
@@ -256,4 +309,5 @@ layout_mode = 2
 
 [connection signal="stamina_changed" from="Player" to="UI" method="_on_player_stamina_changed"]
 [connection signal="mood_changed" from="Player/MoveMachine" to="UI" method="_on_move_machine_mood_changed"]
+[connection signal="mood_exited" from="Player/MoveMachine/Raging" to="Player" method="_on_raging_mood_exited"]
 [connection signal="mood_changed" from="Player/SprintMachine" to="UI" method="_on_sprint_machine_mood_changed"]

--- a/examples/scenes/player.gd
+++ b/examples/scenes/player.gd
@@ -29,8 +29,20 @@ signal stamina_empty
 signal start_rage
 signal end_rage
 
+var _rage_pre_exit := false
+var _timer_started := false
+
 func _unhandled_input(event: InputEvent) -> void:
-	if event.is_action_pressed("ui_text_indent"): # tab key
+	if event.is_action_pressed("ui_text_indent") and not _timer_started: # tab key
 		start_rage.emit()
+		_timer_started = true
 		await get_tree().create_timer(rage_time).timeout
-		end_rage.emit()
+		_timer_started = false
+		if _rage_pre_exit:
+			_rage_pre_exit = false
+		else:
+			end_rage.emit()
+
+func _on_raging_mood_exited(_next_mood: Mood) -> void:
+	_timer_started = false
+	_rage_pre_exit = true


### PR DESCRIPTION
# Changes

* a large number of `@export`s changed on `MoodConditionInput` and `MoodConditionSignal`
* broke up `rule_become_invalid_when` enum on `MoodConditionInput` to `clear_on_action_release`, `clear_on_timeout`, and `clear_on_mood_exit`.
* Updated the **Input State Test** example scene so you can pre-emptively disable Raging (to demonstrate the `trigger_consider_only_if_current` flag).

# Features

* added `clear_on_mood_enter` to `MoodConditionSignal` and `MoodConditionInput`
* added `invert_validity` flag to `MoodConditionSignal`.
* added `trigger_consider_only_if_current` flag to `MoodConditionInput` and `MoodConditionSignal`.

# Fixes

* `_enter_mood` and `_exit_mood` are now actually called when they occur as appropriate.
