### PR TITLE
fix: refactor MoodConditionTimeout to work.

### DIFF
--- a/addons/mood/plugin.cfg
+++ b/addons/mood/plugin.cfg
@@ -3,5 +3,5 @@
 name="Mood"
 description="A flexible, component-state-based Finite State Machine system."
 author="Zoeticist Games"
-version="0.8.2"
+version="0.8.3"
 script="plugin.gd"

--- a/project.godot
+++ b/project.godot
@@ -15,6 +15,7 @@ markdown_book/docs_folder="res://addons/mood/docs/"
 [application]
 
 config/name="Mood"
+config/tags=PackedStringArray("addon", "fsm")
 run/main_scene="res://addons/mood/scenes/editors/mood_ui_transitions_container.tscn"
 config/features=PackedStringArray("4.4", "Forward Plus")
 config/icon="res://icon.svg"


### PR DESCRIPTION
# Changes

* Rewrote `@export` options for `MoodConditionTimeout`:
    * removed `validation_mode` and its underlying `ValidationMode` enum
    * added `invert_validity` bool which changes the initial validity of the condition to `true` and maekes timer trigger set it to `false`.
    * added `persist_timer` bool which will allow the timer's timeout trigger to occur (thus changing validity) (previous behavior: this was always true if `reset_on_reentry` was true)
    * added `on_mood_entry_reset_timer` which will reset an active timer when re-entering the Mood (previous behavior: this was always true if `reset_on_reentry` was true; now, with this controlled by two variables, it's possible to have a timer which persists but does not reset)
    * added `on_mood_entry_start_timer` which will start the timer when entering the parent `Mood`. (previous behavior: this was true for `ValidationMode.VALID_ON_EXIT` and `ValidationMode.VALID_ON_EXIT_UNBOUND`)
    * added `on_mood_exit_start_timer` and `on_mood_exit_reset_timer` which mirror the entry functions (previous behavior: this was only nominally related to `ValidationMode.VALID_ON_ENTER`
* added a `time_left` getter property.
* added the `fsm` tag to the project.

# Fixes

* validity now actually works; before , the lack of `super()` call in `func _ready` resulted in the Mood assignment never happening and the node basically being dead.

# Resolves

#14 
