### PR TITLE
fix: Handle Root Condition Assignment Better

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ mono_crash.*.json
 
 # General ignores
 .DS_Store
+.vscode

--- a/addons/mood/nodes/mood.gd
+++ b/addons/mood/nodes/mood.gd
@@ -105,7 +105,14 @@ signal mood_exited(next_mood: Mood)
 ## When [member MoodMachineChild.machine] has [member MoodMachine.evaluate_moods_directly]
 ## set to [code]true[/code], the root_condition represents the ingress to evaluating the
 ## validity of a Mood, and must be set.
-@export var root_condition: MoodCondition
+@export var root_condition: MoodCondition:
+	set(val):
+		if root_condition == val:
+			return
+
+		root_condition = val
+		notify_property_list_changed()
+		update_configuration_warnings()
 
 #endregion
 

--- a/addons/mood/nodes/mood_child.gd
+++ b/addons/mood/nodes/mood_child.gd
@@ -68,6 +68,9 @@ func _ready() -> void:
 	if not is_instance_valid(mood):
 		return
 
+	if machine.evaluate_moods_directly and not is_instance_valid(mood.root_condition):
+		mood.root_condition = self
+
 	if has_method("_enter_mood"):
 		var em := Callable(self, "_enter_mood")
 		if not mood.mood_entered.is_connected(em):

--- a/addons/mood/plugin.cfg
+++ b/addons/mood/plugin.cfg
@@ -3,5 +3,5 @@
 name="Mood"
 description="A flexible, component-state-based Finite State Machine system."
 author="Zoeticist Games"
-version="0.8.3"
+version="0.8.4"
 script="plugin.gd"


### PR DESCRIPTION
# Related Issues

* #9 
* #10 

# Fixes

* when a `MoodCondition` is added to a `Mood` while `evaluate_moods_directly` is true, if that `Mood` does not have `root_condition` already assigned, it will be assigned to the new node.
* When the `RootCondition` is assigned, the warnings are updated so the flag will go away.

# Changes

* added `.vscode` to the `.gitignore`